### PR TITLE
Fix configured admin routes being inverted

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class AuthenticationProvider {
     if (this._config.authentication_mode === 'admin') {
       // if we are navigating not to an admin route then skip authcheck
       const action = req.url.substr(req.url.lastIndexOf('/') + 1);
-      if (this._config.routes.includes(action)) {
+      if (!this._config.routes.includes(action)) {
         return next();
       }
     }


### PR DESCRIPTION
Hey there,

Another tiny change, sorry - I noticed that this seemed to be the opposite of what the configuration documentation described, and it was making navigating to read routes impossible without a password (logically so).